### PR TITLE
Correct PH Scheme and Related Metadata

### DIFF
--- a/docs/API Overview/pis.md
+++ b/docs/API Overview/pis.md
@@ -145,7 +145,7 @@ The following table mentions the bank account details you must send about the cr
 | NO      | UK.OBIE.IBAN | IBAN           |                |                    |            |
 | NZ      | UK.OBIE.BBAN | Account Number |                |                    |            |
 | PA      | UK.OBIE.BBAN | Account Number |                |                    | Swift Code |
-| PH      | UK.OBIE.IBAN | IBAN           |                |                    | Swift Code |
+| PH      | UK.OBIE.BBAN | Account Number |                |                    | Swift Code |
 | PL      | UK.OBIE.IBAN | IBAN           |                |                    |            |
 | PT      | UK.OBIE.IBAN | IBAN           |                |                    |            |
 | RO      | UK.OBIE.IBAN | IBAN           |                |                    |            |


### PR DESCRIPTION
PR corrects Philippines scheme name and account number name, following remapping in Zoo (#486132)

Revision aligns with PMM countries YAML
